### PR TITLE
Add additional error handling for bad dictionary inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 ## [1.5.0](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/compare/v1.4.0...v1.5.0) (2022-05-03)
 
-
 ### :gift: Feature Changes
 
-* add the `deconstruct` function to the class ([5df23ec](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/5df23ec35290a2cbf7d4c95038af359fd0bf55b5)), closes [#37](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/37)
-
+-   add the `deconstruct` function to the class ([5df23ec](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/5df23ec35290a2cbf7d4c95038af359fd0bf55b5)), closes [#37](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/37)
 
 ### :dart: Test Changes
 
-* add test cases for the `deconstruct` function ([1eafa19](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/1eafa19b487e7db8697e18fda6847194028eab48)), closes [#37](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/37)
+-   add test cases for the `deconstruct` function ([1eafa19](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/1eafa19b487e7db8697e18fda6847194028eab48)), closes [#37](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/37)
 
 ## [1.4.0](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/compare/v1.3.0...v1.4.0) (2022-05-02)
 

--- a/index.js
+++ b/index.js
@@ -77,8 +77,15 @@ class AlphanumericEncoder {
      */
     set dictionary(newDictionary) {
         // Check for empty dictionaries
-        if (newDictionary === null || newDictionary === undefined || newDictionary.length === 0) {
-            throw new RangeError('The dictionary cannot be null, undefined, or an empty string.')
+        if (
+            typeof newDictionary !== 'string' ||
+            newDictionary.length === 0 ||
+            // eslint-disable-next-line no-self-compare
+            newDictionary !== newDictionary // This verifies it wasn't passed NaN
+        ) {
+            throw new RangeError(
+                'The dictionary cannot be null, undefined, boolean, NaN, or an empty string.'
+            )
         }
 
         // Check for invalid characters. Using a regular expression, make sure only letters and numbers are allowed.

--- a/index.test.js
+++ b/index.test.js
@@ -118,6 +118,18 @@ describe('Dictionary Validation', () => {
         }).toThrow(/undefined/)
     })
 
+    test.each([true, false])('Dictionary cannot be boolean %p', (input) => {
+        expect(() => {
+            encoder.dictionary = input
+        }).toThrow(/boolean/)
+    })
+
+    test('Dictionary cannot be NaN', () => {
+        expect(() => {
+            encoder.dictionary = NaN
+        }).toThrow(/NaN/)
+    })
+
     describe('Valid Dictionaries (no lower case)', () => {
         setupNewEncoderForTesting()
 


### PR DESCRIPTION
## Proposed Changes

Boolean values and `NaN` did not result in errors.

## Pull Request Checklist

Please check if your PR fulfills the following requirements:

-   [x] I have read the [CONTRIBUTING](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/blob/main/CONTRIBUTING.md) guidelines
-   [x] My commits follow the [appropriate guidance](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/blob/main/CONTRIBUTING.md#commits)
-   [x] I certify that I have the appropriate permissions to add these changes to the repository
-   [x] An issue is open for the changes proposed
-   [x] I have added/updated tests for new code changes (if applicable)
-   [x] Documentation has been added/updated (if applicable)
-   [x] I built (`npm run build`) locally and pushed all changes

Issues Addressed: #39

## Other Information

None
