### PR TITLE
Fix bug that caused issues in constructor function

### DIFF
--- a/API.md
+++ b/API.md
@@ -32,7 +32,8 @@ A class for encoding and decoding base 10 integers to a custom alphanumeric base
 -   `configOptions` **[object][21]?** Optional object defining initial settings for the class (optional, default `{}`)
 
     -   `configOptions.allowLowerCaseDictionary` **[boolean][22]?** Whether or not to allow lower case letters in the dictionary
-    -   `configOptions.dictionary` **[string][23]?** Starting dictionary to use
+    -   `configOptions.dictionary` **[string][23]?** Starting dictionary to use. Must contain only letters or numbers. Characters cannot be repeated.
+        If `allowLowerCaseDictionary = true`, then lower case letters are not considered the same as upper case. (e.g. 'ABCabc' has 6 unique characters.)
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ### [1.5.1](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/compare/v1.5.0...v1.5.1) (2022-05-14)
 
-
 ### :lady_beetle: Bug Fixes
 
-* improve dictionary type checking ([3f37616](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/3f37616376682edeaeed59dfe66a606a61797de4)), closes [#39](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/39)
+-   improve dictionary type checking ([3f37616](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/commit/3f37616376682edeaeed59dfe66a606a61797de4)), closes [#39](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/issues/39)
 
 ## [1.5.0](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/compare/v1.4.0...v1.5.0) (2022-05-03)
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@
  * A class for encoding and decoding base 10 integers to a custom alphanumeric base representation.
  * @param {object} [configOptions] Optional object defining initial settings for the class
  * @param {boolean} [configOptions.allowLowerCaseDictionary] Whether or not to allow lower case letters in the dictionary
- * @param {string} [configOptions.dictionary] Starting dictionary to use
+ * @param {string} [configOptions.dictionary] Starting dictionary to use. Must contain only letters or numbers. Characters cannot be repeated.
+ * If `allowLowerCaseDictionary = true`, then lower case letters are not considered the same as upper case. (e.g. 'ABCabc' has 6 unique characters.)
  * @example
  * // Import into a project
  * const AlphanumericEncoder = require('alphanumeric-encoder')
@@ -47,10 +48,10 @@ class AlphanumericEncoder {
 
         // Process the options. If the user included any, then the if statements will evaluate truthy and try to
         //  set the appropriate values.
-        if (configOptions.allowLowerCaseDictionary) {
+        if ('allowLowerCaseDictionary' in configOptions) {
             this.allowLowerCaseDictionary = configOptions.allowLowerCaseDictionary
         }
-        if (configOptions.dictionary) {
+        if ('dictionary' in configOptions) {
             this.dictionary = configOptions.dictionary
         }
     }
@@ -76,7 +77,7 @@ class AlphanumericEncoder {
      * encoder.dictionary = 'ABCDA' // Throws error because the letter 'A' is repeated
      */
     set dictionary(newDictionary) {
-        // Check for empty dictionaries
+        // Check for empty or wrong type dictionaries
         if (
             typeof newDictionary !== 'string' ||
             newDictionary.length === 0 ||

--- a/index.test.js
+++ b/index.test.js
@@ -73,12 +73,32 @@ describe('Allow Lower Case Dictionaries', () => {
         }
     )
 
+    test.each([true, 1, [123], { value: 1 }])(
+        'allowLowerCaseDictionary with truthy value in setup: new AlphanumericEncoder({ allowLowerCaseDictionary: %p })',
+        (truthyTestValue) => {
+            const setupEncoder = new AlphanumericEncoder({
+                allowLowerCaseDictionary: truthyTestValue
+            })
+            expect(setupEncoder.allowLowerCaseDictionary).toBeTruthy()
+        }
+    )
+
     test.each([false, 0, null, undefined])(
         'allowLowerCaseDictionary with falsy value %p',
         (truthyTestValue) => {
             // @ts-ignore
             encoder.allowLowerCaseDictionary = truthyTestValue
             expect(encoder.allowLowerCaseDictionary).toBeFalsy()
+        }
+    )
+
+    test.each([false, 0, null, undefined])(
+        'allowLowerCaseDictionary with falsy value in setup: new AlphanumericEncoder({ allowLowerCaseDictionary: %p })',
+        (truthyTestValue) => {
+            const setupEncoder = new AlphanumericEncoder({
+                allowLowerCaseDictionary: truthyTestValue
+            })
+            expect(setupEncoder.allowLowerCaseDictionary).toBeFalsy()
         }
     )
 
@@ -120,15 +140,29 @@ describe('Dictionary Validation', () => {
 
     test.each([true, false])('Dictionary cannot be boolean %p', (input) => {
         expect(() => {
+            // @ts-ignore
             encoder.dictionary = input
         }).toThrow(/boolean/)
     })
 
     test('Dictionary cannot be NaN', () => {
         expect(() => {
+            // @ts-ignore
             encoder.dictionary = NaN
         }).toThrow(/NaN/)
     })
+
+    test.each([true, false, null, undefined, '', NaN, { dictionary: 'ABC' }, ['ABC'], 'ABCDA'])(
+        'Cannot pass bad dictionary arguments in constructor: new AlphanumericEncoder({dictionary: %p}',
+        (dictionaryInput) => {
+            expect(() => {
+                // eslint-disable-next-line no-unused-vars
+                const setupEncoder = new AlphanumericEncoder({
+                    dictionary: dictionaryInput
+                })
+            }).toThrow()
+        }
+    )
 
     describe('Valid Dictionaries (no lower case)', () => {
         setupNewEncoderForTesting()


### PR DESCRIPTION
## Proposed Changes

Fix behavior that allowed bad dictionary values to make it through if passed in the constructor function.

## Pull Request Checklist

Please check if your PR fulfills the following requirements:

-   [X] I have read the [CONTRIBUTING](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/blob/main/CONTRIBUTING.md) guidelines
-   [X] My commits follow the [appropriate guidance](https://github.com/M-Scott-Lassiter/Alphanumeric-Encoder/blob/main/CONTRIBUTING.md#commits)
-   [X] I certify that I have the appropriate permissions to add these changes to the repository
-   [X] An issue is open for the changes proposed
-   [X] I have added/updated tests for new code changes (if applicable)
-   [X] Documentation has been added/updated (if applicable)
-   [X] I built (`npm run build`) locally and pushed all changes

Issues Addressed: #41

## Other Information

None
